### PR TITLE
Adding Thyrza_4302 to activerepos

### DIFF
--- a/activerepos.csv
+++ b/activerepos.csv
@@ -14,3 +14,4 @@ PG ID,Title,participants,Repo
 12297,Slave Narratives- a Folk History of Slavery in the United States,cliotropic,https://github.com/GITenberg/Slave-Narratives--a-Folk-History-of-Slavery-in-the-United-StatesFlorida-Narratives_12297
 23174,A Good For Nothing,NickCarneiro,https://github.com/GITenberg/A-Good-For-Nothing1876_23174
 25308,Eugenics and Other Evils,tmtmtmtm,https://github.com/GITenberg/Eugenics-and-Other-Evils_25308
+4302,Thyrza,samwilson,https://github.com/GITenberg/Thyrza_4302


### PR DESCRIPTION
@samwilson made an asciidoc edition of *Thyrza* in this [pull request](https://github.com/GITenberg/Thyrza_4302/pull/1)

This adds Thyrza to our list of currently active repos.